### PR TITLE
Fix superimpose

### DIFF
--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -30,8 +30,8 @@ using std::vector;
 void Timeseries::init( Configf& configf ) {
   series_size_type superimpose = 1;
   configf.optional("Superimpose", superimpose);
-  double duration = 0.0; ///< Duration of the stimulus.
-  double onset = 0.0; ///< Onset time for the stimulus.
+  double duration = 0.0; // Duration of the stimulus.
+  double onset = 0.0; // Onset time for the stimulus.
   for( series_size_type i=0; i<superimpose; i++ ) {
     if( superimpose > 0 ) {
       configf.next("Stimulus");

--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -29,19 +29,24 @@ using std::vector;
 
 void Timeseries::init( Configf& configf ) {
   series_size_type superimpose = 1;
-  configf.optional("Superimpose",superimpose);
+  configf.optional("Superimpose", superimpose);
+  double duration = 0.0; ///< Duration of the stimulus.
+  double onset = 0.0; ///< Onset time for the stimulus.
   for( series_size_type i=0; i<superimpose; i++ ) {
     if( superimpose > 0 ) {
       configf.next("Stimulus");
     }
     vector<string> mode = configf.arb("-");
 
-    configf.optional("Onset",t);
-    t = -t;
-    if( !configf.optional("Duration",cease) ) {
-      if( configf.optional("Cease",cease) ) {
-        cease += t;
-      }
+    // Set stimulus onset time.
+    if(!configf.optional("Onset", onset)){
+      onset = 0.0;
+    }
+    t = -onset; //Initialise stimulus time relative to onset.
+
+    // Set stimulus duration.
+    if(!configf.optional("Duration", duration) ) {
+      duration = inf; //Unspecified => whole simulation.
     }
 
     vector<double> temp_node;
@@ -84,7 +89,7 @@ void Timeseries::init( Configf& configf ) {
     }
     // END PUT YOUR TIMEFUNCTION HERE
     series[i]->t = t;
-    series[i]->cease = cease;
+    series[i]->duration = duration;
     for(double j : temp_node) {
       series[i]->node.push_back( j-1 );
     }
@@ -94,7 +99,7 @@ void Timeseries::init( Configf& configf ) {
 }
 
 Timeseries::Timeseries( size_type nodes, double deltat, size_type index )
-  : NF(nodes,deltat,index), series(), t(0.0), cease(1000.0) {
+  : NF(nodes,deltat,index), series() {
 }
 
 Timeseries::~Timeseries() {
@@ -109,7 +114,7 @@ void Timeseries::fire( vector<double>& Q ) const {
   Q.resize(nodes,0);
   for(auto serie : series) { // for each timeseries
     // if the timeseries is active
-    if( serie->t>=0 && serie->t<serie->cease ) {
+    if( (serie->t >= 0) && (serie->t < serie->duration) ) {
       serie->fire(temp);
       // then copy the temporary firing to the final firing
       for(double j : serie->node) {

--- a/src/timeseries.cpp
+++ b/src/timeseries.cpp
@@ -109,12 +109,13 @@ Timeseries::~Timeseries() {
 }
 
 void Timeseries::fire( vector<double>& Q ) const {
-  vector<double> temp(nodes,0);
+  vector<double> temp(nodes, 0.0);
   Q.clear();
-  Q.resize(nodes,0);
+  Q.resize(nodes, 0.0);
   for(auto serie : series) { // for each timeseries
     // if the timeseries is active
     if( (serie->t >= 0) && (serie->t < serie->duration) ) {
+      temp.assign(nodes, 0.0);
       serie->fire(temp);
       // then copy the temporary firing to the final firing
       for(double j : serie->node) {

--- a/src/timeseries.h
+++ b/src/timeseries.h
@@ -15,6 +15,7 @@
 #include "random.h"     // Random;
 
 // C++ standard library headers
+#include <limits>   // std::numeric_limits<double>::infinity()
 #include <vector>   // std::vector;
 
 class Timeseries : public NF {
@@ -24,8 +25,9 @@ class Timeseries : public NF {
 
   std::vector<Timeseries*> series;
   std::vector<double> node;
-  double t = 0.0;
-  double cease = 0.0;
+  double inf = std::numeric_limits<double>::infinity();
+  double t = 0.0;     ///< Current time relative to stimulus onset.
+  double duration = inf; ///< Duration of the stimulus.
  public:
   Timeseries(const Timeseries&) = delete;  // No copy constructor allowed.
   Timeseries() = delete;                   // No default constructor allowed.

--- a/src/timeseries.h
+++ b/src/timeseries.h
@@ -25,7 +25,7 @@ class Timeseries : public NF {
 
   std::vector<Timeseries*> series;
   std::vector<double> node;
-  double inf = std::numeric_limits<double>::infinity();
+  double inf = std::numeric_limits<double>::infinity(); ///< Infinity
   double t = 0.0;     ///< Current time relative to stimulus onset.
   double duration = inf; ///< Duration of the stimulus.
  public:


### PR DESCRIPTION
#136 
This pull request fixes the duration for superimposed stimulus timeseries.
Also fixes an issue caused by the temp vector in the `Timeseries::fire` method not being initialised for superimposed timeseries.

Images generated with the fixed code, for the three examples provided in the issue (#136), are below. 
 
## Case 1
![superimpose_test_case_a](https://user-images.githubusercontent.com/1515979/33916286-bf727c3a-dff3-11e7-9143-31e9e3f82a6f.jpg)

## Case 2
![superimpose_test_case_b](https://user-images.githubusercontent.com/1515979/33916290-c426830c-dff3-11e7-8f67-2afb2f2e629a.jpg)

## Case 3
![superimpose_test_case_c](https://user-images.githubusercontent.com/1515979/33916358-11284cee-dff4-11e7-9361-f093554471ce.jpg)
